### PR TITLE
fix(pr-title): Don't skip the whole job on merge queues

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     # The action does not support running on merge_group events,
     # but if the check succeeds in the PR there is no need to check it again.
-    if: github.event_name == 'pull_request_target'
     env:
       # Github's terrible version of a 'ternary operator'
       # https://github.com/actions/runner/issues/409#issuecomment-752775072
@@ -38,9 +37,15 @@ jobs:
       breaking: ${{ steps.breaking.outputs.breaking }}
       # Whether the PR body contains a "BREAKING CHANGE:" footer describing the breaking change.
       has_breaking_footer: ${{ steps.breaking.outputs.has_breaking_footer }}
+    # The following steps are only run on pull_request_target events. We add the
+    # `if` statements to each individual step since we want the job to still
+    # succeed in merge queues. Skipping the job completely doesn't seem to work
+    # when called as a reusable workflow (the worker is never started, and the
+    # queued job just hangs there).
     steps:
       - name: Validate the PR title format
         uses: amannn/action-semantic-pull-request@v5
+        if: github.event_name == 'pull_request_target'
         id: lint_pr_title
         with:
           # Configure which types are allowed (newline-delimited).
@@ -93,6 +98,7 @@ jobs:
       # we can use a simple regex that looks for a '!:' sequence. It could be
       # more complex, but we don't care about false positives.
       - name: Check for breaking change flag
+        if: github.event_name == 'pull_request_target'
         id: breaking
         run: |
           if [[ "${PR_TITLE}" =~ ^.*\!:.*$ ]]; then
@@ -116,30 +122,30 @@ jobs:
       # not contain a "BREAKING CHANGE:" footer.
       - name: Require "BREAKING CHANGE:" footer for breaking changes
         id: breaking-comment
-        if: ${{ steps.breaking.outputs.breaking == 'true' && steps.breaking.outputs.has_breaking_footer == 'false' }}
+        if: ${{ github.event_name == 'pull_request_target' && steps.breaking.outputs.breaking == 'true' && steps.breaking.outputs.has_breaking_footer == 'false' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-title-lint-error
           message: |
-            Hey there and thank you for opening this pull request! 👋🏼
+            Hey there and thank you for opening this pull request! 👋
 
             It looks like your proposed title indicates a breaking change. If that's the case,
             please make sure to include a "BREAKING CHANGE:" footer in the body of the pull request
             describing the breaking change and any migration instructions.
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       - name: Fail if the footer is required but missing
-        if: ${{ steps.breaking.outputs.breaking == 'true' && steps.breaking.outputs.has_breaking_footer == 'false' }}
+        if: ${{ github.event_name == 'pull_request_target' && steps.breaking.outputs.breaking == 'true' && steps.breaking.outputs.has_breaking_footer == 'false' }}
         run: exit 1
 
       - name: Post a comment if the PR badly formatted
         uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
-        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        if: always() && github.event_name == 'pull_request_target'  && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error
           message: |
-            Hey there and thank you for opening this pull request! 👋🏼
+            Hey there and thank you for opening this pull request! 👋
 
             We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
             and it looks like your proposed title needs to be adjusted.
@@ -166,6 +172,7 @@ jobs:
       # This step doesn't run if any of the previous checks fails.
       - name: Delete previous comments
         uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request_target'
         with:
           header: pr-title-lint-error
           delete: true

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ on:
 
 jobs:
     check-title:
-        name: Validate Conventional Commit PR title
-        if: github.event_name == 'pull_request_target'
         uses: CQCL/hugrverse-actions/.github/workflows/pr-title.yml@main
         secrets:
             GITHUB_PAT: ${{ secrets.GITHUB_PAT }}


### PR DESCRIPTION
Skipping the jobs completely when running on the merge queue doesn't seem to work when called as a reusable workflow for a required check.
The worker is never started, and the queued job just hangs there.

This PR moves the `if` checks to each step instead, so the general job should now succeed in merge queues.