### PR TITLE
ci(pr-title): Fix comments not getting deleted after they get fixed

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -165,7 +165,7 @@ jobs:
             ```
             ${{ steps.lint_pr_title.outputs.error_message }}
             ```
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
 
       # Delete previous comments when the issues have been resolved
@@ -176,4 +176,4 @@ jobs:
         with:
           header: pr-title-lint-error
           delete: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}


### PR DESCRIPTION
The `BREAKING CHANGE` footer check used a different token than the _delete comments_ step, so it wasn't getting deleted after the problem got fixed.