### PR TITLE
chore: Setup CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# for syntax see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+
+# base rule, hugrverse team is codeowner for whole repo
+* @CQCL/hugrverse


### PR DESCRIPTION
Adding the main group instead of a subteam. This is a small repo, so we should avoid siloing.