### PR TITLE
fix(pr-title): Don't require writeable GITHUB_TOKEN

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -6,6 +6,7 @@ on:
     secrets:
       GITHUB_PAT:
         description: 'The github token for the user that will post comments.'
+        required: true
   # The caller should use these triggers on their workflow file
   pull_request_target:
     branches:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     secrets:
       GITHUB_PAT:
-        description: 'The github token for the user that will post comments. Defaults to GITHUB_TOKEN'
+        description: 'The github token for the user that will post comments.'
   # The caller should use these triggers on their workflow file
   pull_request_target:
     branches:
@@ -19,9 +19,6 @@ on:
   merge_group:
     types: [checks_requested]
 
-permissions:
-  pull-requests: write
-
 jobs:
   main:
     name: Validate Conventional Commit PR title
@@ -31,7 +28,7 @@ jobs:
     env:
       # Github's terrible version of a 'ternary operator'
       # https://github.com/actions/runner/issues/409#issuecomment-752775072
-      GITHUB_TOKEN: ${{ secrets.GITHUB_PAT != '' && secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
     outputs:
       # Whether the PR title indicates a breaking change.
       breaking: ${{ steps.breaking.outputs.breaking }}

--- a/README.md
+++ b/README.md
@@ -70,14 +70,6 @@ The fine-grained `GITHUB_PAT` secret must include the following permissions:
 | --- | --- |
 | Pull requests | Read and write |
 
-If the parameter is not defined, it defaults to the runner's `GITHUB_TOKEN`.
-This requires giving additional permissions to the included token:
-
-```yaml
-permissions:
-  pull-requests: write
-```
-
 ### [`add-to-project`](https://github.com/CQCL/hugrverse-actions/blob/main/.github/workflows/add-to-project.yml)
 
 Adds new issues to a GitHub project board when they are created.


### PR DESCRIPTION
(in addition to the GITHUB_PAT parameter)

Removes the fallback into the implicit GITHUB_TOKEN when no token parameter is given.
Doing that made the workflow always require write access on the runtime token, even if was not used.