### PR TITLE
fix(add-to-project): Path to input project url

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -23,7 +23,7 @@ env:
     #
     # Github's terrible version of a 'ternary operator'
     # https://github.com/actions/runner/issues/409#issuecomment-752775072
-    PROJECT_URL: ${{ github.repository == 'CQCL/hugrverse-actions' && 'https://github.com/orgs/CQCL-DEV/projects/10' || github.event.inputs.project-url }}
+    PROJECT_URL: ${{ github.repository == 'CQCL/hugrverse-actions' && 'https://github.com/orgs/CQCL-DEV/projects/10' || inputs.project-url }}
 
 jobs:
   add-to-project:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -30,6 +30,11 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
+      - name: Fail if project-url is not set
+        if: env.PROJECT_URL == ''
+        run: |
+          echo "The project-url input is required."
+          exit 1
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: ${{ env.PROJECT_URL }}


### PR DESCRIPTION
Uses the correct path to access the `workflow_call`'s input.

https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#inputs-context