### PR TITLE
fix(coverage-trend): Use the current workflow's name

### DIFF
--- a/.github/workflows/coverage-trend.yml
+++ b/.github/workflows/coverage-trend.yml
@@ -20,11 +20,11 @@ jobs:
       msg: ${{ steps.make_msg.outputs.msg }}
       should_notify: ${{ steps.get_coverage.outputs.should_notify }}
     steps:
+      # Downloads the artifact from the most recent successful run
       - name: Download commit sha of the most recent successful run
+        continue-on-error: true
         uses: dawidd6/action-download-artifact@v6
         with:
-          # Downloads the artifact from the most recent successful run
-          workflow: 'coverage-trend.yml'
           name: head-sha.txt
           if_no_artifact_found: ignore
       - name: Get today's and last run's coverage trends from codecov


### PR DESCRIPTION
Now that this gets `workflow_call`ed, we should use the caller's workflow name to look for the previous run stats.
This is the default behaviour of `action-download-artifact` when no workflow name is specified.

Failing run due to mismatched name:
https://github.com/CQCL/hugr/actions/runs/11547150535/job/32136579831