### PR TITLE
feat(rs-semver-checks): Early fail if the crate has build errors

### DIFF
--- a/.github/workflows/rs-semver-checks.yml
+++ b/.github/workflows/rs-semver-checks.yml
@@ -32,6 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head.sha }}
           path: PR_BRANCH
       - name: Checkout baseline
         uses: actions/checkout@v4
@@ -54,6 +55,11 @@ jobs:
       - name: Install cargo-semver-checks
         run: cargo binstall -y cargo-semver-checks
 
+      # Abort if the crate has build errors.
+      - name: Check for build errors
+        id: build
+        run: cargo check --all-targets
+
       # Run cargo-semver-checks against the PR's target branch.
       - name: Check for public API changes
         id: check-changes
@@ -75,6 +81,9 @@ jobs:
             echo
             echo EOF
           } >> $GITHUB_OUTPUT
+
+          echo "semver-checks diagnostic:\n"
+          cat diagnostic.txt
       
       # Check if the PR title contains a breaking change flag,
       # to change the feedback message.


### PR DESCRIPTION
Closes #29 

drive-by: Use the right "head commit" when running in a `pull_request_target` event. Otherwise we where fetching the base ref, and not detecting anything. See [this run](https://github.com/CQCL/hugr/actions/runs/12118219519/job/33782281012?pr=1723#step:2:72), where both HEAD and BASE checkouts use the same sha.