### PR TITLE
fix(rs-semver-checks): `cd` into checked out repo when `cargo check`ing

### DIFF
--- a/.github/workflows/rs-semver-checks.yml
+++ b/.github/workflows/rs-semver-checks.yml
@@ -58,7 +58,9 @@ jobs:
       # Abort if the crate has build errors.
       - name: Check for build errors
         id: build
-        run: cargo check --all-targets
+        run: |
+          cd PR_BRANCH
+          cargo check --all-targets
 
       # Run cargo-semver-checks against the PR's target branch.
       - name: Check for public API changes


### PR DESCRIPTION
In #30 I forgot we are checking out the repo to a different directory, so we need to `cd` before running anything -.-'

See failing run due to missing `Cargo.toml`: https://github.com/CQCL/hugr/actions/runs/12118534964/job/33783222406?pr=1723#step:9:15