### PR TITLE
fix(breaking-change-to-main): Ensure that env vars are escaped when injecting them into bash

### DIFF
--- a/.github/workflows/breaking-change-to-main.yml
+++ b/.github/workflows/breaking-change-to-main.yml
@@ -36,11 +36,13 @@ jobs:
       - name: Check for breaking change in title
         id: breaking
         run: |
-          if [[ "${{ github.event.pull_request.title }}" =~ ^.*\!:.*$ ]]; then
+          if [[ "${PR_TITLE}" =~ ^.*\!:.*$ ]]; then
             echo "breaking=true" >> $GITHUB_OUTPUT
           else
             echo "breaking=false" >> $GITHUB_OUTPUT
           fi
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
 
       - name: Post comment for breaking change targeting main
         if: |
@@ -66,7 +68,7 @@ jobs:
           steps.breaking.outputs.breaking == 'true' && 
           github.event.pull_request.base.ref == env.PROTECTED_BRANCH
         run: |
-          echo "Breaking changes are not allowed to be merged into `${{ env.PROTECTED_BRANCH }}`."
+          echo "Breaking changes are not allowed to be merged into `${PROTECTED_BRANCH}`."
           exit 1
 
       # only make it to this point if we have not failed above


### PR DESCRIPTION
Variables should be always put into an env var before using them inside bash scripts. Otherwise you may end up [evaluating arbitrary code](https://github.com/CQCL/hugr/actions/runs/14759134813/job/41435128150#step:3:2) 💥