### PR TITLE
fix(breaking-change-to-main): No backticks in echo command

### DIFF
--- a/.github/workflows/breaking-change-to-main.yml
+++ b/.github/workflows/breaking-change-to-main.yml
@@ -68,7 +68,7 @@ jobs:
           steps.breaking.outputs.breaking == 'true' && 
           github.event.pull_request.base.ref == env.PROTECTED_BRANCH
         run: |
-          echo "Breaking changes are not allowed to be merged into `${PROTECTED_BRANCH}`."
+          echo "Breaking changes are not allowed to be merged into '${PROTECTED_BRANCH}'."
           exit 1
 
       # only make it to this point if we have not failed above


### PR DESCRIPTION
Using backticks in `echo` was a bad idea. I don't know why it was working before, but it doesn't work now (it tries to evaluate "main" as a bash command). Bash is great...