### PR TITLE
fix(breaking-main): Define a single fail/no-fail job

### DIFF
--- a/.github/workflows/breaking-change-to-main.yml
+++ b/.github/workflows/breaking-change-to-main.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   main:
-    name: Check for breaking changes targeting main
+    name: Check breaking changes
     if: ${{ github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     env:
@@ -81,7 +81,17 @@ jobs:
 
   # Avoids the workflow from being skipped when triggered by a non-pull_request_target event.
   never-skipped:
-    name: Never skipped
+    name: Required checks
+    needs: [main]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - run: echo "success"
+      - name: Fail if required checks failed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "Required checks failed"
+          echo "Please check the logs for more information"
+          exit 1
+      - name: Pass if required checks passed
+        run: |
+          echo "All required checks passed"

--- a/.github/workflows/breaking-change-to-main.yml
+++ b/.github/workflows/breaking-change-to-main.yml
@@ -80,7 +80,7 @@ jobs:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
   # Avoids the workflow from being skipped when triggered by a non-pull_request_target event.
-  never-skipped:
+  required-checks:
     name: Required checks
     needs: [main]
     if: ${{ !cancelled() }}


### PR DESCRIPTION
Makes sure we have a single job to match against as a github pass requirement.

When the check job gets skipped we cannot use it as a required check (since `skipped != successful`), so we need a separate job that succeeds if `skipped || success`.
I also shortened the job names, since the workflow name already has the full description.