### PR TITLE
fix: Make the breaking-flag-in-title regex more robust

### DIFF
--- a/.github/workflows/breaking-change-to-main.yml
+++ b/.github/workflows/breaking-change-to-main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check for breaking change in title
         id: breaking
         run: |
-          if [[ "${PR_TITLE}" =~ ^.*\!:.*$ ]]; then
+          if [[ "${PR_TITLE}" =~ ^[^:(]*(\(.*\))?\!:.*$ ]]; then
             echo "breaking=true" >> $GITHUB_OUTPUT
           else
             echo "breaking=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -103,7 +103,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         id: breaking
         run: |
-          if [[ "${PR_TITLE}" =~ ^.*\!:.*$ ]]; then
+          if [[ "${PR_TITLE}" =~ ^[^:(]*(\(.*\))?\!:.*$ ]]; then
             echo "breaking=true" >> $GITHUB_OUTPUT
           else
             echo "breaking=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/rs-semver-checks.yml
+++ b/.github/workflows/rs-semver-checks.yml
@@ -93,7 +93,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         id: breaking-pr
         run: |
-          if [[ "${PR_TITLE}" =~ ^.*\!:.*$ ]]; then
+          if [[ "${PR_TITLE}" =~ ^[^:(]*(\(.*\))?\!:.*$ ]]; then
             echo "breaking=true" >> $GITHUB_OUTPUT
           else
             echo "breaking=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Improves the regex that detect the `!` conventional commit flag, so that it detects examples like:

```
fix!: Revert "fix: …
fix!: Revert "fix!: …fix: Revert "fix: …
fix(tag!:)!: Revert "fix: …
fix(tag!:)!: Revert "fix!: …
```

But it does **not** match
```
fix: Revert "fix: …
fix: Revert "fix!: …
fix(tag!:): Revert "fix: …
fix(tag!:): Revert "fix!: …
```

The previous impl matched any `!:` sequence on the title, so it had some false positives.

Regex101 run:
https://regex101.com/r/zD5HRp/1