### PR TITLE
fix: Breaking title regex

### DIFF
--- a/.github/workflows/breaking-change-to-main.yml
+++ b/.github/workflows/breaking-change-to-main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check for breaking change in title
         id: breaking
         run: |
-          if [[ "${PR_TITLE}" =~ ^[^:(]*(\(.*\))?\!:.*$ ]]; then
+          if echo "${PR_TITLE}" | grep -qE '^[^:(]*(\(.*\))?\!:.*$'; then
             echo "breaking=true" >> $GITHUB_OUTPUT
           else
             echo "breaking=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -103,7 +103,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         id: breaking
         run: |
-          if [[ "${PR_TITLE}" =~ ^[^:(]*(\(.*\))?\!:.*$ ]]; then
+          if echo "${PR_TITLE}" | grep -qE '^[^:(]*(\(.*\))?\!:.*$'; then
             echo "breaking=true" >> $GITHUB_OUTPUT
           else
             echo "breaking=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/rs-semver-checks.yml
+++ b/.github/workflows/rs-semver-checks.yml
@@ -93,7 +93,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         id: breaking-pr
         run: |
-          if [[ "${PR_TITLE}" =~ ^[^:(]*(\(.*\))?\!:.*$ ]]; then
+          if echo "${PR_TITLE}" | grep -qE '^[^:(]*(\(.*\))?\!:.*$'; then
             echo "breaking=true" >> $GITHUB_OUTPUT
           else
             echo "breaking=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The change in #47 was incorrect, as bash `~=` operator does not actually support regex but a weird pattern syntax instead -.-

Here we are using `grep -E` instead.

Tested locally using bash.