### PR TITLE
feat(pr-title): Hide error details in bot message

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -192,10 +192,15 @@ jobs:
             ```
             and include a "BREAKING CHANGE:" footer in the body of the pull request.
 
-            Details:
+            <details>
+
+            <summary>Details</summary>
+
             ```
             ${{ steps.lint_pr_title.outputs.error_message }}
             ```
+
+            </details>
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
 


### PR DESCRIPTION
Hides the error message inside an expandable label, to try and make the bot help less confusing.