### PR TITLE
fix(pr-title): RFC comment not being shown

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -146,7 +146,7 @@ jobs:
         id: rfc-tag
         run: |
           shopt -s nocasematch
-          if [[ "${PR_TITLE}" =~ ^rfc:.*$ ]]; then
+          if echo "${PR_TITLE}" | grep -qiE '^rfc(\(.*\))?(\!)?:.*$'; then
             echo "rfc=true" >> $GITHUB_OUTPUT
           else
             echo "rfc=false" >> $GITHUB_OUTPUT
@@ -155,7 +155,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
       - name: Post comment if the PR is an RFC
         id: rfc-tag-comment
-        if: ${{ github.event_name == 'pull_request_target' && steps.rfc-tag.outputs.rfc == 'true' }}
+        if: always() && (github.event_name == 'pull_request_target') && (steps.rfc-tag.outputs.rfc == 'true')
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-title-lint-error
@@ -165,7 +165,7 @@ jobs:
             This PR is marked as an RFC. Please make sure to change the conventional commit type before merging.
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       - name: Terminate the workflow after posting the RFC comment
-        if: ${{ github.event_name == 'pull_request_target' && steps.rfc-tag.outputs.rfc == 'true' }}
+        if: always() && (github.event_name == 'pull_request_target') && (steps.rfc-tag.outputs.rfc == 'true')
         run: exit 1
 
       - name: Post a comment if the PR badly formatted


### PR DESCRIPTION
The bot is supposed to detect `rfc:` title prefixes and post a custom message when failing.
The step was being skipped due to missing `always()`.

See https://github.com/CQCL/guppylang/actions/runs/16720641768/job/47324103976?pr=1127#step:7:1

drive-by: Make the regex case-insensitive and accept `(scope)` and breaking flags (This is mostly a copy of the regex in the `breaking` step).