### PR TITLE
fix(semver-checks): Fix baseline fetch for python and clear up scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,8 @@ The fine-grained `GITHUB_PAT` secret must include the following permissions:
 
 Runs [`griffe`](https://mkdocstrings.github.io/griffe/) on a PR against the base branch,
 and reports back if there are breaking changes in the Python API.
-Suggests adding a breaking change flag to the PR title if necessary. 
+
+If the PR has a breaking change, posts a comment with a summary of the changes.
 
 ### Usage
 ```yaml
@@ -272,7 +273,7 @@ jobs:
       - uses: CQCL/hugrverse-actions/py-semver-checks@main
         with:
           packages: python-package1 path/to/python-package2
-          baseline-rev: main  # Defaults to base branch of the PR
+          baseline-rev: main  # If not present, defaults to base branch of the PR
           token: ${{ secrets.GITHUB_PAT }}
 ```
 
@@ -291,22 +292,25 @@ To run this workflow on pull requests from forks, ensure the action is triggered
 
 Runs `cargo-semver-checks` on a PR against the base branch, and reports back if
 there are breaking changes.
-Suggests adding a breaking change flag to the PR title if necessary. 
+
+If the PR has a breaking change, posts a comment with a summary of the changes.
 
 ### Usage
-```yaml
-name: Rust Semver Checks
-on:
-  pull_request_target:
-    branches:
-      - main
 
+```yaml
 jobs:
-    rs-semver-checks:
-        uses: CQCL/hugrverse-actions/.github/workflows/rs-semver-checks.yml@main
-        secrets:
-            GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+  semver-checks:
+    name: Rust semver-checks 🦀
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+    steps:
+      - uses: CQCL/hugrverse-actions/rs-semver-checks@main
+        with:
+          baseline-rev: main  # If not present, defaults to base branch of the PR
+          token: ${{ secrets.GITHUB_PAT }}
 ```
+
 
 The workflow compares against the base branch of the PR by default. Use the `baseline-rev` input to specify a different base commit.
 
@@ -320,33 +324,6 @@ The fine-grained `GITHUB_PAT` secret must include the following permissions:
 
 Note that repository secrets are not available to forked repositories on `pull_request` events.
 To run this workflow on pull requests from forks, ensure the action is triggered by a `pull_request_target` event instead.
-
-### Using the Semver action directly
-
-If you need more customisation, you can use the composite action of the same name.
-This can be integrated in an existing workflow, so that the action can e.g. be preceded
-by setup steps that install dependencies. See the [workflow](https://github.com/CQCL/hugrverse-actions/blob/main/.github/workflows/rs-semver-checks.yml) file for a full example.
-
-```yaml
-jobs:
-  semver-checks:
-    name: Rust semver-checks 🦀
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
-    steps:
-      - name: Install apt dependencies
-        if: ${{ inputs.apt-dependencies != '' }}
-        run: |
-          echo "Installing apt dependencies: $APT_DEPENDENCIES"
-          sudo apt-get install -y $APT_DEPENDENCIES
-        env:
-          APT_DEPENDENCIES: ${{ inputs.apt-dependencies }}
-      - uses: CQCL/hugrverse-actions/rs-semver-checks@main
-        with:
-          baseline-rev: ${{ inputs.baseline-rev }}
-          token: ${{ secrets.GITHUB_PAT }}
-```
 
 ## [`slack-notifier`](https://github.com/CQCL/hugrverse-actions/blob/main/.github/workflows/slack-notifier.yml)
 

--- a/py-semver-checks/action.py
+++ b/py-semver-checks/action.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "griffe ~=1.14.0",
+#     "colorama ~=0.4.6",
+# ]
+# ///
+
 """Script to check for breaking changes across multiple Python packages."""
 
 import colorama
@@ -19,12 +27,14 @@ if __name__ == "__main__":
     breaking_changes = []
     for package in args.packages:
         package = Path(package)
-        baseline_package = load_git(package.name, search_paths=[package.parent], ref=args.baseline)
-        head_package = load_git(package.name, search_paths=[package.parent], ref="HEAD")    
+        baseline_package = load_git(
+            package.name, search_paths=[package.parent], ref=args.baseline
+        )
+        head_package = load_git(package.name, search_paths=[package.parent], ref="HEAD")
         breaking_changes += list(find_breaking_changes(baseline_package, head_package))
-    
+
     for change in breaking_changes:
         print(change.explain(style=ExplanationStyle.VERBOSE))
-    
+
     if breaking_changes:
         exit(1)

--- a/py-semver-checks/action.yml
+++ b/py-semver-checks/action.yml
@@ -17,7 +17,7 @@ runs:
         ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head.sha }}
     - name: Fetch baseline
       shell: bash
-      run: git fetch origin $BASELINE_REV --depth 1
+      run: git fetch origin "$BASELINE_REV" --depth 1
       env:
         BASELINE_REV: ${{ inputs.baseline-rev || github.event.pull_request.base.sha || github.event.merge_group.base.sha }}
 

--- a/py-semver-checks/action.yml
+++ b/py-semver-checks/action.yml
@@ -4,10 +4,9 @@ description: Action running Python semver-checks
 inputs:
   baseline-rev:
     description: "The base rev to compare against. Defaults to the PR's base branch."
-    type: string
     required: false
   token:
-    description: 'A Github PAT to post comments.'
+    description: "A Github PAT to post comments."
     required: true
 
 runs:
@@ -18,18 +17,14 @@ runs:
         ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head.sha }}
     - name: Fetch baseline
       shell: bash
-      run: |
-          git fetch origin ${{ inputs.baseline-rev }} --depth 1
-    
+      run: git fetch origin $BASELINE_REV --depth 1
+      env:
+        BASELINE_REV: ${{ inputs.baseline-rev || github.event.pull_request.base.sha || github.event.merge_group.base.sha }}
+
     - name: Set up uv
       uses: astral-sh/setup-uv@v5
       with:
         enable-cache: true
-    - name: Install griffe
-      shell: bash
-      run: |
-        uv venv
-        uv pip install griffe
 
     - name: Check for public API changes
       id: check-changes
@@ -38,7 +33,8 @@ runs:
         # Don't fail the workflow when the script returns a non-zero exit code.
         set +e
 
-        uv run ${{ github.action_path }}/action.py --baseline ${{ inputs.baseline-rev || github.event.pull_request.base.sha || github.event.merge_group.base.sha }} --packages ${{ inputs.packages }} > diagnostic.txt
+        echo "Running semver-checks on packages: $PACKAGES for baseline: $BASELINE_REV"
+        uv run "$ACTION_PATH/action.py" --baseline "$BASELINE_REV" --packages "$PACKAGES" > diagnostic.txt
         if [ "$?" -ne 0 ]; then
           echo "breaking=true" >> $GITHUB_OUTPUT
         else
@@ -55,7 +51,11 @@ runs:
         echo "semver-checks diagnostic:"
         echo
         cat diagnostic.txt
-    
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        BASELINE_REV: ${{ inputs.baseline-rev || github.event.pull_request.base.sha || github.event.merge_group.base.sha }}
+        PACKAGES: ${{ inputs.packages }}
+
     # Check if the PR title contains a breaking change flag,
     # to change the feedback message.
     - name: Check for breaking change flag

--- a/rs-semver-checks/action.yml
+++ b/rs-semver-checks/action.yml
@@ -4,16 +4,10 @@ description: Action running Rust semver-checks
 inputs:
   baseline-rev:
     description: "The base rev to compare against. Defaults to the PR's base branch."
-    type: string
-    required: false 
+    required: false
   token:
-    description: 'A Github PAT to post comments.'
+    description: "A Github PAT to post comments."
     required: true
-
-env:
-  CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 runs:
   using: composite
@@ -70,7 +64,7 @@ runs:
 
         echo "semver-checks diagnostic:\n"
         cat diagnostic.txt
-    
+
     # Check if the PR title contains a breaking change flag,
     # to change the feedback message.
     - name: Check for breaking change flag
@@ -130,7 +124,7 @@ runs:
             
           </details>
         GITHUB_TOKEN: ${{ inputs.token }}
-    
+
     - name: Remove the checked out directories
       shell: bash
       run: |
@@ -149,4 +143,3 @@ runs:
         header: rs-semver-checks
         delete: true
         GITHUB_TOKEN: ${{ inputs.token }}
-


### PR DESCRIPTION
- Cleans up both the `rs-semver-checks` and `py-semver-checks`
  - Both workflows had invalid attributes that are not allowed in composite actions (leftovers from the port from reusable workflows).
  - `py-` inserted `${{...}}` workflow expressions directly into bash scripts. This is a security issue as there is no escaping done on them, replaced them for env variables.
  - `py-` wasn't fetching the baseline commit in some cases. This should fix #57 
  - Uses [`uv script`s](https://docs.astral.sh/uv/guides/scripts/#running-a-script-with-dependencies) for the `py-` action script, instead of setting up dependencies manually in the workflow.
  
- Cleans up the README, and removes the legacy reusable workflow example for `rs-`.