### PR TITLE
fix(py-semver-checks): Fix error on multiple py packages

### DIFF
--- a/py-semver-checks/action.yml
+++ b/py-semver-checks/action.yml
@@ -34,7 +34,7 @@ runs:
         set +e
 
         echo "Running semver-checks on packages: $PACKAGES for baseline: $BASELINE_REV"
-        uv run "$ACTION_PATH/action.py" --baseline "$BASELINE_REV" --packages "$PACKAGES" > diagnostic.txt
+        uv run "$ACTION_PATH/action.py" --baseline "$BASELINE_REV" --packages $PACKAGES > diagnostic.txt
         if [ "$?" -ne 0 ]; then
           echo "breaking=true" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
The checker script expects multiple arguments when defining packages, instead of a single space-separated string.

This should fix the error seen on guppylang
https://github.com/CQCL/guppylang/actions/runs/17610099782/job/50029878711?pr=1252#step:7:226

(tested by running the script locally)