### PR TITLE
fix(semver-checks): Use the latest commit in the BASELINE branch

### DIFF
--- a/py-semver-checks/action.yml
+++ b/py-semver-checks/action.yml
@@ -14,12 +14,12 @@ runs:
   steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head.sha }}
+        ref: ${{ github.event.pull_request.head.merge_commit_sha || github.event.merge_group.head.sha }}
     - name: Fetch baseline
       shell: bash
       run: git fetch origin "$BASELINE_REV" --depth 1
       env:
-        BASELINE_REV: ${{ inputs.baseline-rev || github.event.pull_request.base.sha || github.event.merge_group.base.sha }}
+        BASELINE_REV: ${{ inputs.baseline-rev || github.event.pull_request.base.ref || github.event.merge_group.base.ref }}
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v5

--- a/rs-semver-checks/action.yml
+++ b/rs-semver-checks/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Checkout baseline
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.baseline-rev || github.event.pull_request.base.sha || github.event.merge_group.base.sha }}
+        ref: ${{ inputs.baseline-rev || github.event.pull_request.base.ref || github.event.merge_group.base.ref }}
         path: BASELINE_BRANCH
     - uses: mozilla-actions/sccache-action@v0.0.9
     - name: Install stable toolchain


### PR DESCRIPTION
We were using `base.sha` when fetching the baseline for semver checking, which corresponds to a commit on which the PR is based, but is not always the latest one (I haven't seen this specified anywhere, but seen the behaviour from testing).

This PR changes it to use `base.ref`, so the checkout action always fetches the latest value.

For the PR's branch we use `merge_commit_sha`, which always corresponds to the result of merging the diff against the latest value of `base.ref`.