### PR TITLE
fix(semver-checks): Mismatched BASELINE sha definitions

### DIFF
--- a/py-semver-checks/action.yml
+++ b/py-semver-checks/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       run: git fetch origin "$BASELINE_REV" --depth 1
       env:
-        BASELINE_REV: ${{ inputs.baseline-rev || github.event.pull_request.base.ref || github.event.merge_group.base.ref }}
+        BASELINE_REV: ${{ inputs.baseline-rev || github.event.pull_request.base.sha || github.event.merge_group.base.sha }}
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v5
@@ -33,7 +33,10 @@ runs:
         # Don't fail the workflow when the script returns a non-zero exit code.
         set +e
 
-        echo "Running semver-checks on packages: $PACKAGES for baseline: $BASELINE_REV"
+        echo "Running semver-checks on packages: $PACKAGES"
+        echo "- Baseline commit: $BASELINE_REV"
+        echo "- Head commit: $HEAD_REV"
+
         uv run "$ACTION_PATH/action.py" --baseline "$BASELINE_REV" --packages $PACKAGES > diagnostic.txt
         if [ "$?" -ne 0 ]; then
           echo "breaking=true" >> $GITHUB_OUTPUT
@@ -54,6 +57,7 @@ runs:
       env:
         ACTION_PATH: ${{ github.action_path }}
         BASELINE_REV: ${{ inputs.baseline-rev || github.event.pull_request.base.sha || github.event.merge_group.base.sha }}
+        HEAD_REV: ${{ github.event.pull_request.head.merge_commit_sha || github.event.merge_group.head.sha }}
         PACKAGES: ${{ inputs.packages }}
 
     # Check if the PR title contains a breaking change flag,

--- a/rs-semver-checks/action.yml
+++ b/rs-semver-checks/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Checkout baseline
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.baseline-rev || github.event.pull_request.base.ref || github.event.merge_group.base.ref }}
+        ref: ${{ inputs.baseline-rev || github.event.pull_request.base.sha || github.event.merge_group.base.sha }}
         path: BASELINE_BRANCH
     - uses: mozilla-actions/sccache-action@v0.0.9
     - name: Install stable toolchain


### PR DESCRIPTION
`BASELINE_REV` is defined in multiple places in `py-semver-checks`, but #63 only changed one occurrence.

This PR rolls backs some of those changes.

drive-by: Change the baseline `ref` for its `sha` in `rs-semver-checks` too, since that one seems to behave more correctly... (things are [really underdocumented](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request) -.-)