### PR TITLE
feat(semver-checks): Make token for posting comments optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,13 +253,15 @@ The fine-grained `GITHUB_PAT` secret must include the following permissions:
 Runs [`griffe`](https://mkdocstrings.github.io/griffe/) on a PR against the base branch,
 and reports back if there are breaking changes in the Python API.
 
-If the PR has a breaking change, posts a comment with a summary of the changes.
+If `token` is supplied, it also tries to post a sticky pull request comment with
+a summary of the changes. Otherwise, it only writes a job summary that can be
+consulted in the "Checks" tab of the pull request.
 
 ### Usage
 ```yaml
 name: Python Semver Checks
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -267,8 +269,9 @@ jobs:
   semver-checks:
     name: Python semver-checks 🐍
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: quantinuum/hugrverse-actions/py-semver-checks@main
         with:
@@ -279,14 +282,20 @@ jobs:
 
 ### Token Permissions
 
-The fine-grained `GITHUB_PAT` secret must include the following permissions:
+The `token` input is optional. If it is omitted, the action skips sticky pull
+request comments and only writes the job summary.
+
+When a token is supplied, it must include the following permissions:
 
 | Permission | Access |
 | --- | --- |
 | Pull requests | Read and write |
 
-Note that repository secrets are not available to forked repositories on `pull_request` events.
-To run this workflow on pull requests from forks, ensure the action is triggered by a `pull_request_target` event instead.
+Sticky pull request comments are best-effort and do not fail the semver check if
+the token cannot write comments. Note that repository secrets are not available
+to forked repositories on `pull_request` events, so forked pull requests should
+omit the token and rely on the job summary. Do not use `pull_request_target` for
+this action unless the pull request code being checked out and run is trusted.
 
 ## [`rs-semver-checks`](https://github.com/quantinuum/hugrverse-actions/blob/main/.github/workflows/rs-semver-checks.yml)
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,9 @@ To run this workflow on pull requests from forks, ensure the action is triggered
 Runs `cargo-semver-checks` on a PR against the base branch, and reports back if
 there are breaking changes.
 
-If the PR has a breaking change, posts a comment with a summary of the changes.
+If `token` is supplied, it also tries to post a sticky pull request comment with
+a summary of the changes. Otherwise, it only writes a job summary that can be
+consulted in the "Checks" tab of the pull request.
 
 ### Usage
 
@@ -302,8 +304,9 @@ jobs:
   semver-checks:
     name: Rust semver-checks 🦀
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: quantinuum/hugrverse-actions/rs-semver-checks@main
         with:
@@ -316,14 +319,20 @@ The workflow compares against the base branch of the PR by default. Use the `bas
 
 ### Token Permissions
 
-The fine-grained `GITHUB_PAT` secret must include the following permissions:
+The `token` input is optional. If it is omitted, the action skips sticky pull
+request comments and only writes the job summary.
+
+When a token is supplied, it must include the following permissions:
 
 | Permission | Access |
 | --- | --- |
 | Pull requests | Read and write |
 
-Note that repository secrets are not available to forked repositories on `pull_request` events.
-To run this workflow on pull requests from forks, ensure the action is triggered by a `pull_request_target` event instead.
+Sticky pull request comments are best-effort and do not fail the semver check if
+the token cannot write comments. Note that repository secrets are not available
+to forked repositories on `pull_request` events, so forked pull requests should
+omit the token and rely on the job summary. Do not use `pull_request_target` for
+this action unless the pull request code being checked out and built is trusted.
 
 ## [`slack-notifier`](https://github.com/quantinuum/hugrverse-actions/blob/main/.github/workflows/slack-notifier.yml)
 

--- a/py-semver-checks/action.yml
+++ b/py-semver-checks/action.yml
@@ -65,6 +65,7 @@ runs:
 
         {
           echo 'semver_checks_diagnostic<<EOF'
+          # Cleanup ANSI escape sequences.
           cat diagnostic.txt  | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g'
           echo
           echo EOF
@@ -126,7 +127,7 @@ runs:
           echo "<summary>Breaking changes summary</summary>"
           echo
           echo '```'
-          sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' diagnostic.txt
+          printf '%s\n' "$DIAGNOSTIC"
           echo '```'
           echo
           echo "</details>"
@@ -135,6 +136,7 @@ runs:
         BREAKING: ${{ steps.check-changes.outputs.breaking }}
         BREAKING_PR: ${{ steps.breaking-pr.outputs.breaking }}
         COMMENT_TOKEN: ${{ inputs.token }}
+        DIAGNOSTIC: ${{ steps.check-changes.outputs.semver_checks_diagnostic }}
 
     # Post a diagnostics comment if there are breaking changes and the PR has been marked as breaking.
     - name: Post a comment about the breaking changes. PR marked as breaking.

--- a/py-semver-checks/action.yml
+++ b/py-semver-checks/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: "A string containing a space-separated list of packages to check for breaking changes."
     required: true
   token:
-    description: "A Github PAT to post comments."
-    required: true
+    description: "A GitHub PAT or token to post comments. If unset, comments are skipped."
+    required: false
   baseline-rev:
     description: "The base rev to compare against. Defaults to the PR's base branch."
     required: false
@@ -100,10 +100,47 @@ runs:
         echo "breaking: ${{ steps.check-changes.outputs.breaking }}"
         echo "breaking-pr: ${{ steps.breaking-pr.outputs.breaking }}"
 
+    - name: Write job summary
+      shell: bash
+      run: |
+        {
+          echo "## Python semver checks"
+          echo
+
+          if [ "$BREAKING" = "true" ] && [ "$BREAKING_PR" = "true" ]; then
+            echo "This PR contains breaking changes to the public Python API and is marked as breaking."
+          elif [ "$BREAKING" = "true" ]; then
+            echo "This PR contains breaking changes to the public Python API, but is not marked as breaking."
+            echo "Please deprecate the old API instead, if possible, or mark the PR with a \`!\` to indicate a breaking change."
+          else
+            echo "No breaking public Python API changes were detected."
+          fi
+
+          if [ -z "$COMMENT_TOKEN" ]; then
+            echo
+            echo "No comment token was supplied, so sticky pull request comments were skipped."
+          fi
+
+          echo
+          echo "<details>"
+          echo "<summary>Breaking changes summary</summary>"
+          echo
+          echo '```'
+          sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' diagnostic.txt
+          echo '```'
+          echo
+          echo "</details>"
+        } >> "$GITHUB_STEP_SUMMARY"
+      env:
+        BREAKING: ${{ steps.check-changes.outputs.breaking }}
+        BREAKING_PR: ${{ steps.breaking-pr.outputs.breaking }}
+        COMMENT_TOKEN: ${{ inputs.token }}
+
     # Post a diagnostics comment if there are breaking changes and the PR has been marked as breaking.
     - name: Post a comment about the breaking changes. PR marked as breaking.
-      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'true' }}
+      if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'true' }}
       uses: marocchino/sticky-pull-request-comment@v2
+      continue-on-error: true
       with:
         header: py-semver-checks
         message: |
@@ -121,8 +158,9 @@ runs:
 
     # Post a help comment if there are breaking changes, and the PR hasn't been marked as breaking.
     - name: Post a comment about the breaking changes. PR *not* marked as breaking.
-      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'false' }}
+      if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'false' }}
       uses: marocchino/sticky-pull-request-comment@v2
+      continue-on-error: true
       with:
         header: py-semver-checks
         message: |
@@ -148,7 +186,8 @@ runs:
     # This step doesn't run if any of the previous checks fails.
     - name: Delete previous comments
       uses: marocchino/sticky-pull-request-comment@v2
-      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'false' }}
+      if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'false' }}
+      continue-on-error: true
       with:
         header: py-semver-checks
         delete: true

--- a/rs-semver-checks/action.yml
+++ b/rs-semver-checks/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: "The base rev to compare against. Defaults to the PR's base branch."
     required: false
   token:
-    description: "A Github PAT to post comments."
-    required: true
+    description: "A GitHub PAT or token to post comments. If unset, comments are skipped."
+    required: false
 
 runs:
   using: composite
@@ -117,10 +117,51 @@ runs:
         echo "breaking-pr: ${{ steps.breaking-pr.outputs.breaking }}"
         echo "new_package: ${{ steps.check-changes.outputs.new_package }}"
 
+    - name: Write job summary
+      shell: bash
+      run: |
+        {
+          echo "## Rust semver checks"
+          echo
+
+          if [ "$NEW_PACKAGE" = "true" ]; then
+            echo "A new Rust package was added to the workspace and is not present in the baseline."
+            echo "Skipping semver checks."
+          elif [ "$BREAKING" = "true" ] && [ "$BREAKING_PR" = "true" ]; then
+            echo "This PR contains breaking changes to the public Rust API and is marked as breaking."
+          elif [ "$BREAKING" = "true" ]; then
+            echo "This PR contains breaking changes to the public Rust API, but is not marked as breaking."
+            echo "Please deprecate the old API instead, if possible, or mark the PR with a \`!\` to indicate a breaking change."
+          else
+            echo "No breaking public Rust API changes were detected."
+          fi
+
+          if [ -z "$COMMENT_TOKEN" ]; then
+            echo
+            echo "No comment token was supplied, so sticky pull request comments were skipped."
+          fi
+
+          echo
+          echo "<details>"
+          echo "<summary>cargo-semver-checks output</summary>"
+          echo
+          echo '```'
+          cat PR_BRANCH/diagnostic.txt
+          echo '```'
+          echo
+          echo "</details>"
+        } >> "$GITHUB_STEP_SUMMARY"
+      env:
+        BREAKING: ${{ steps.check-changes.outputs.breaking }}
+        BREAKING_PR: ${{ steps.breaking-pr.outputs.breaking }}
+        COMMENT_TOKEN: ${{ inputs.token }}
+        NEW_PACKAGE: ${{ steps.check-changes.outputs.new_package }}
+
     # Post a message if a new package is detected (not present in baseline)
     - name: New package detected; skipping semver checks
-      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.new_package == 'true' }}
+      if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.new_package == 'true' }}
       uses: marocchino/sticky-pull-request-comment@v2
+      continue-on-error: true
       with:
         header: rs-semver-checks
         message: |
@@ -139,8 +180,9 @@ runs:
 
     # Post a diagnostics comment if there are breaking changes and the PR has been marked as breaking.
     - name: Post a comment about the breaking changes. PR marked as breaking.
-      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'true' }}
+      if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'true' }}
       uses: marocchino/sticky-pull-request-comment@v2
+      continue-on-error: true
       with:
         header: rs-semver-checks
         message: |
@@ -158,8 +200,9 @@ runs:
 
     # Post a help comment if there are breaking changes, and the PR hasn't been marked as breaking.
     - name: Post a comment about the breaking changes. PR *not* marked as breaking.
-      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'false' }}
+      if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'false' }}
       uses: marocchino/sticky-pull-request-comment@v2
+      continue-on-error: true
       with:
         header: rs-semver-checks
         message: |
@@ -190,7 +233,8 @@ runs:
     # This step doesn't run if any of the previous checks fails.
     - name: Delete previous comments
       uses: marocchino/sticky-pull-request-comment@v2
-      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'false' && steps.check-changes.outputs.new_package == 'false' }}
+      if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'false' && steps.check-changes.outputs.new_package == 'false' }}
+      continue-on-error: true
       with:
         header: rs-semver-checks
         delete: true


### PR DESCRIPTION
The `semver-checks` actions post comments when a problem is found, using a provided github token with `pull-request: write` access.

The issue is that running CI for PRs coming from forks we don't have access to the token secrets, so the action call just failed instead. (We used to run this on a `pull_request_target` event, which worked but was a security issue).

This PR makes the `token` parameter optional for both `py-` and `rs-` semver checks.
Comments will only be posted if the token is provided.

Instead, now we always generate a `GITHUB_STEP_SUMMARY`, which should provide feedback without fumbling with comment tokens.

Also updated the README to warn against using `pull_request_target`.