### PR TITLE
fix: Upgrade actions used in callable actions ahead of node deprecations

### DIFF
--- a/py-semver-checks/action.yml
+++ b/py-semver-checks/action.yml
@@ -141,7 +141,7 @@ runs:
     # Post a diagnostics comment if there are breaking changes and the PR has been marked as breaking.
     - name: Post a comment about the breaking changes. PR marked as breaking.
       if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'true' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       continue-on-error: true
       with:
         header: py-semver-checks
@@ -161,7 +161,7 @@ runs:
     # Post a help comment if there are breaking changes, and the PR hasn't been marked as breaking.
     - name: Post a comment about the breaking changes. PR *not* marked as breaking.
       if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'false' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       continue-on-error: true
       with:
         header: py-semver-checks
@@ -187,7 +187,7 @@ runs:
     # Delete previous comments when the issues have been resolved
     # This step doesn't run if any of the previous checks fails.
     - name: Delete previous comments
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'false' }}
       continue-on-error: true
       with:

--- a/py-semver-checks/action.yml
+++ b/py-semver-checks/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Checkout PR's head
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.merge_commit_sha || github.event.merge_group.head.sha }}
         # This will fetch the baseline commit, defined as the first parent of the merge commit.

--- a/py-semver-checks/action.yml
+++ b/py-semver-checks/action.yml
@@ -41,7 +41,7 @@ runs:
         BASELINE_INPUT: ${{ inputs.baseline-rev }}
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 

--- a/rs-semver-checks/action.yml
+++ b/rs-semver-checks/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Checkout PR's head
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.merge_commit_sha || github.event.merge_group.head.sha }}
         path: PR_BRANCH
@@ -38,7 +38,7 @@ runs:
         BASELINE_INPUT: ${{ inputs.baseline-rev }}
 
     - name: Checkout baseline
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ steps.define-baseline.outputs.BASELINE_REV }}
         path: BASELINE_BRANCH

--- a/rs-semver-checks/action.yml
+++ b/rs-semver-checks/action.yml
@@ -43,7 +43,7 @@ runs:
         ref: ${{ steps.define-baseline.outputs.BASELINE_REV }}
         path: BASELINE_BRANCH
 
-    - uses: mozilla-actions/sccache-action@v0.0.9
+    - uses: mozilla-actions/sccache-action@v0.0.10
     - name: Install stable toolchain
       uses: dtolnay/rust-toolchain@stable
 

--- a/rs-semver-checks/action.yml
+++ b/rs-semver-checks/action.yml
@@ -160,7 +160,7 @@ runs:
     # Post a message if a new package is detected (not present in baseline)
     - name: New package detected; skipping semver checks
       if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.new_package == 'true' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       continue-on-error: true
       with:
         header: rs-semver-checks
@@ -181,7 +181,7 @@ runs:
     # Post a diagnostics comment if there are breaking changes and the PR has been marked as breaking.
     - name: Post a comment about the breaking changes. PR marked as breaking.
       if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'true' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       continue-on-error: true
       with:
         header: rs-semver-checks
@@ -201,7 +201,7 @@ runs:
     # Post a help comment if there are breaking changes, and the PR hasn't been marked as breaking.
     - name: Post a comment about the breaking changes. PR *not* marked as breaking.
       if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'false' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       continue-on-error: true
       with:
         header: rs-semver-checks
@@ -232,7 +232,7 @@ runs:
     # Delete previous comments when the issues have been resolved
     # This step doesn't run if any of the previous checks fails.
     - name: Delete previous comments
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       if: ${{ inputs.token != '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'false' && steps.check-changes.outputs.new_package == 'false' }}
       continue-on-error: true
       with:


### PR DESCRIPTION
Ahead of Node v20 deprecations, to avoid deprecation warnings such as
<img width="1191" height="134" alt="image" src="https://github.com/user-attachments/assets/4ec7d432-bcc5-4792-b799-350746dfff4b" />
on using PRs.

All of these versions are already used in this repositories own workflows, and have been tried and tested in other environments, so there should be little to no risk.

As a little bonus also upgrades the `setup-uv` action.